### PR TITLE
pghub-baseのバージョンアップに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,19 @@ Or install it yourself as:
 
 ## Usage
 
+### Get github access token
+
+### Deploy to heroku
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/playground-live/pghub-server/tree/issue_title)
+
+### Deploy manually
 - mount in routes.rb
 
 ```ruby
 mount Pghub::Base::Engine => 'some path'
 ```
 
-- Get github access token
 - Add following settings to config/initializers/pghub.rb
 
 ```ruby
@@ -39,7 +45,24 @@ end
 ```
 
 - Deploy to server
-- Set webhook to your repository
+
+
+### Set webhook to your repository
+
+|||
+|:-:|:-:|
+|URL|heroku'sURL/github_webhooks|
+|Content-Type|application/json|
+|Secret||
+|event|check the following events|
+
+#### events
+- commit comment
+- issue comment
+- issues
+- pull request
+- pull request comment
+- pull request review comment
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Or install it yourself as:
 - mount in routes.rb
 
 ```ruby
-mount Pghub::Base::Engine => 'some path'
+mount Pghub::Base::Engine => 'some/path'
 ```
 
 - Add following settings to config/initializers/pghub.rb
@@ -51,7 +51,7 @@ end
 
 |||
 |:-:|:-:|
-|URL|heroku'sURL/github_webhooks|
+|URL|heroku'sURL/github_webhooks or heroku'sURL/some/path|
 |Content-Type|application/json|
 |Secret||
 |event|check the following events|

--- a/lib/pghub/issue_title/version.rb
+++ b/lib/pghub/issue_title/version.rb
@@ -1,5 +1,5 @@
 module Pghub
   module IssueTitle
-    VERSION = "1.1"
+    VERSION = "1.1.0"
   end
 end

--- a/lib/pghub/issue_title/version.rb
+++ b/lib/pghub/issue_title/version.rb
@@ -1,5 +1,5 @@
 module Pghub
   module IssueTitle
-    VERSION = "1.0.0"
+    VERSION = "1.1"
   end
 end

--- a/pghub-issue_title.gemspec
+++ b/pghub-issue_title.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "pghub-base", "~> 1.0.0"
+  spec.add_dependency "pghub-base", ">= 1.0.0"
 end


### PR DESCRIPTION
# WHAT
- gemspecにおけるバージョン表記を`~> 1.0.0`から`>= 1.0.0`に変更
- READMEにusageの詳細とDeploy to herokuボタン配置

# WHY
- pghub-baseを`2.0`にupdateするため
